### PR TITLE
Add model as top level and other fixes...

### DIFF
--- a/flambe/__init__.py
+++ b/flambe/__init__.py
@@ -28,7 +28,7 @@ main_logging.disable(main_logging.WARNING)
 from flambe.compile import Component, Schema, save, load
 from flambe.compile import save_state_to_file, load_state_from_file
 from flambe.logging import log
-from flambe import compile, dataset, experiment, field, learn, nlp, vision, export
+from flambe import compile, dataset, experiment, field, learn, nlp, vision, export, model
 from flambe import cluster, metric, nn, runner, sampler, runnable, tokenizer
 from flambe.version import VERSION as __version__
 from flambe.logo import ASCII_LOGO

--- a/flambe/cluster/cluster.py
+++ b/flambe/cluster/cluster.py
@@ -300,7 +300,7 @@ class Cluster(Runnable):
 
         Raises
         ------
-        RemoteCommandError
+        errors.RemoteCommandError
             If at least one commands is not successful in at
             least one host.
 
@@ -859,42 +859,43 @@ class Cluster(Runnable):
 
         return ret
 
-    def install_extensions_in_factories(self, extensions) -> None:
-        """Install local + pypi extensions in all the factories.
+    def install_extensions_in_orchestrator(self, extensions: Dict[str, str]) -> None:
+        """Install local + pypi extensions in the orchestrator
+
+        Parameters
+        ----------
+        extension: Dict[str, str]
+            The extensions, as a dict from module_name to location
 
         Raises
         ------
-        ClusterError
+        errors.RemoteCommandError
+            If could not install an extension.
+        man_errors.ClusterError
+            If the orchestrator was not loaded.
+
+        """
+        if not self.orchestrator:
+            raise man_errors.ClusterError("Orchestrator instance was not loaded.")
+
+        self.orchestrator.install_extensions(extensions)
+
+    def install_extensions_in_factories(self, extensions: Dict[str, str]) -> None:
+        """Install local + pypi extensions in all the factories.
+
+        Parameters
+        ----------
+        extension: Dict[str, str]
+            The extensions, as a dict from module_name to location
+
+        Raises
+        ------
+        errors.RemoteCommandError
             If could not install an extension
 
         """
-        cmd = ['python3', '-m', 'pip', 'install', '-U', '--user']
         for f in self.factories:
-            for ext, resource in extensions.items():
-                curr_cmd = cmd[:]
-
-                if 'PIP' in self.config:
-                    host = self.config['PIP'].get('HOST', None)
-                    if host:
-                        curr_cmd.extend(["--trusted-host", host])
-
-                    host_url = self.config['PIP'].get('HOST_URL', None)
-                    if host_url:
-                        curr_cmd.extend(["--extra-index-url", host_url])
-
-                if os.path.exists(resource):
-                    # Package is local
-                    if os.sep not in resource:
-                        resource = f"./{resource}"
-                else:
-                    # Package follows pypi notation: "torch>=0.4.1,<1.1"
-                    resource = f"{resource}"
-
-                curr_cmd.append(resource)
-
-                ret = f._run_cmd(" ".join(curr_cmd))
-                if not ret.success:
-                    raise man_errors.ClusterError(f"Could not install package in {resource}")
+            f.install_extensions(extensions)
 
     def get_remote_env(self) -> RemoteEnvironment:
         """Get the RemoteEnvironment for this cluster.

--- a/flambe/runner/run.py
+++ b/flambe/runner/run.py
@@ -76,6 +76,14 @@ def main(args: argparse.Namespace) -> None:
                                                                 destiny, all_hosts=True)
 
                     new_secrets = cluster.send_secrets(whitelist=["GITHUB", "PIP"])
+
+                    # Installing the extensions is crutial as flambe
+                    # will execute without '-i' flag and therefore
+                    # will assume that the extensions are installed
+                    # in the orchestrator.
+                    cluster.install_extensions_in_orchestrator(new_extensions)
+                    logger.info(cl.GR("Extensions installed in Orchestrator"))
+
                     runnable.setup_inject_env(cluster=cluster,
                                               extensions=new_extensions,
                                               force=args.force)


### PR DESCRIPTION
- Add `model` as a top level import. This was a bug and didn't allow `LogisticRegression` to be used in YAML.
- Installation flow for extensions is much more clear and bug free.