### PR TITLE
Ignore everything under .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,11 +287,7 @@ pyvenv.cfg
 pip-selfcheck.json
 
 ### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode/
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files


### PR DESCRIPTION
The files under .vscode are meant to be user specific,
and should not be checked in to the repo at all. So,
Let's ignore it completely.

This is more of a practice PR. I noticed that my vscode setting files were not ignored. Actually, you guys deliberately chose not to ignore them. Any reason why? I think it's best we ignore them so that we don't accidentally check them in.