### PR TITLE
Add public IPs to env

### DIFF
--- a/flambe/cluster/cluster.py
+++ b/flambe/cluster/cluster.py
@@ -916,5 +916,7 @@ class Cluster(Runnable):
             key=f"{self.orchestrator.get_home_path()}/{const.PRIVATE_KEY}",
             orchestrator_ip=self.orchestrator.private_host,
             factories_ips=[f.private_host for f in self.factories],
-            user=self.orchestrator.username
+            user=self.orchestrator.username,
+            public_orchestrator_ip=self.orchestrator.host,
+            public_factories_ips=[f.host for f in self.factories]
         )

--- a/flambe/runnable/environment.py
+++ b/flambe/runnable/environment.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import List, Any, Optional
 from flambe.compile import Registrable
 
 
@@ -24,19 +24,28 @@ class RemoteEnvironment(Registrable):
     user: str
         The username of all machines. This implementations assumes
         same usename for all machines
+    public_orchestrator_ip: Optional[str]
+        The public orchestrator IP, if available.
+    public_factories_ips: Optional[List[str]]
+        The public factories IPs, if available.
 
     """
 
     def __init__(self,
                  key: str,
-                 orchestrator_ip: str,
+                 public_orchestrator_ip: str,
                  factories_ips: List[str],
                  user: str,
+                 orchestrator_ip: Optional[str] = None,
+                 public_factories_ips: Optional[List[str]] = None,
                  **kwargs) -> None:
         self.key = key
         self.orchestrator_ip = orchestrator_ip
         self.factories_ips = factories_ips
         self.user = user
+
+        self.public_orchestrator_ip = public_orchestrator_ip
+        self.public_factories_ips = public_factories_ips
 
     @classmethod
     def to_yaml(cls, representer: Any, node: Any, tag: str) -> Any:
@@ -44,6 +53,8 @@ class RemoteEnvironment(Registrable):
         kwargs = {'key': node.key,
                   'orchestrator_ip': node.orchestrator_ip,
                   'factories_ips': node.factories_ips,
+                  'public_orchestrator_ip': node.public_orchestrator_ip,
+                  'public_factories_ips': node.public_factories_ips,
                   'user': node.user}
         return representer.represent_mapping(tag, kwargs)
 

--- a/flambe/runnable/environment.py
+++ b/flambe/runnable/environment.py
@@ -33,10 +33,10 @@ class RemoteEnvironment(Registrable):
 
     def __init__(self,
                  key: str,
-                 public_orchestrator_ip: str,
+                 orchestrator_ip: str,
                  factories_ips: List[str],
                  user: str,
-                 orchestrator_ip: Optional[str] = None,
+                 public_orchestrator_ip: Optional[str] = None,
                  public_factories_ips: Optional[List[str]] = None,
                  **kwargs) -> None:
         self.key = key


### PR DESCRIPTION
The `environment` that is passed to all `ClusterRunnables` now contains information about the public IPs of both the orchestrator and factories.

This allows the different `ClusterRunnables` to have that information everywhere besides the `setup` method. For example, this is useful for adding logs or notifications in the `run` method pointing to the public IPs.