### PR TITLE
Hot fix in tmux checks

### DIFF
--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -1042,7 +1042,7 @@ class OrchestratorInstance(Instance):
         # Sometimes tmux command returns failure (because of some
         # timeout) but website is running.
         # Adding this extra check in that case.
-        if res.success and self.is_report_site_running():
+        if res.success or self.is_report_site_running():
             logger.info(cl.BL(f"Report site at http://{self.host}:{port}"))
         else:
             raise errors.RemoteCommandError(f"Report site failed to run. {res.msg}")

--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -1182,6 +1182,9 @@ class OrchestratorInstance(Instance):
 
         ret = self._run_cmd(cmd)
 
+        # Sometimes tmux command returns failure (because of some
+        # timeout) but flambe is running.
+        # Adding this extra check in that case.
         if ret.success or self.is_flambe_running():
             logger.info(cl.GR("Running flambe in Orchestrator"))
         else:

--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -1182,7 +1182,7 @@ class OrchestratorInstance(Instance):
 
         ret = self._run_cmd(cmd)
 
-        if ret.success:
+        if ret.success or self.is_flambe_running():
             logger.info(cl.GR("Running flambe in Orchestrator"))
         else:
             raise errors.RemoteCommandError(f"Not able to run flambe. {ret.msg}")

--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -733,7 +733,7 @@ class Instance(object):
         bool
 
         """
-        cmd = "ps -e | grep -P ^flambe$"  # -w flag for exact string match
+        cmd = "ps axco command | grep -P ^flambe$"
         ret = self._run_cmd(cmd)
         return ret.success
 
@@ -1068,7 +1068,7 @@ class OrchestratorInstance(Instance):
         bool
 
         """
-        cmd = "ps -e | grep flambe-site"
+        cmd = "ps axco command | grep -P ^flambe-site$"
         ret = self._run_cmd(cmd)
         return ret.success
 


### PR DESCRIPTION
There was a bug in this check.

The idea is that sometimes `tmux` gives a timeout and the command fails. A new check is added to see if the service launched using `tmux` is running, prior to launching an error.