### PR TITLE
Fix timeout feature!

### DIFF
--- a/flambe/cluster/aws.py
+++ b/flambe/cluster/aws.py
@@ -753,6 +753,10 @@ class AWSCluster(Cluster):
                 f_id = self._get_instance_id_by_host(f.host)
                 if f_id:
                     mins = fact_t * 60 if fact_t > 0 else 5
+                    # Adding fake data for CPU usage to avoid the alarm
+                    # triggering immediately in case the machine was
+                    # already idle
+                    self._put_fake_cloudwatch_data(f_id, value=100, points=10)
                     self._create_cloudwatch_event(f_id, mins=mins, cpu_thresh=0.5)
                     logger.info(cl.YE(f"{f.host} timeout of {mins} mins set"))
         else:
@@ -764,6 +768,10 @@ class AWSCluster(Cluster):
             orch_t = self.orchestrator_timeout
             if orch_t >= 0:
                 mins = orch_t * 60 if orch_t > 0 else 5
+                # Adding fake data for CPU usage to avoid the alarm
+                # triggering immediately in case the machine was already
+                # idle
+                self._put_fake_cloudwatch_data(orch_id, value=100, points=10)
                 self._create_cloudwatch_event(orch_id, mins=mins, cpu_thresh=4)
                 logger.info(cl.YE(f"{self.orchestrator.host} timeout of {mins} set"))
             else:
@@ -782,7 +790,10 @@ class AWSCluster(Cluster):
         except botocore.exceptions.ParamValidationError:
             raise errors.ClusterError(f"Could not delete alarm for {instance_id}")
 
-    def _put_fake_cloudwatch_data(self, instance_id: str) -> None:
+    def _put_fake_cloudwatch_data(self,
+                                  instance_id: str,
+                                  value: int = 100,
+                                  points: int = 10) -> None:
         """Put fake CPU Usage metric in an instance.
 
         This method is useful to avoid triggering alarms when they are
@@ -795,6 +806,13 @@ class AWSCluster(Cluster):
         ----------
         instance_id: str
             The ID of the EC2 instance
+        value: int
+            The CPU percent value to use. Defaults to 100
+        points: int
+            The amount of past minutes from the current time
+            to generate metric points. For example, if points is 10,
+            then 10 data metrics will be generated for the past 10
+            minutes, one per minute.
 
         """
         try:

--- a/flambe/cluster/aws.py
+++ b/flambe/cluster/aws.py
@@ -130,6 +130,7 @@ class AWSCluster(Cluster):
         self.factories_type = factories_type
         self.orchestrator_type = orchestrator_type
 
+        self.region_name = region_name
         self.sess = self._get_boto_session(region_name)
 
         self.ec2_resource = self.sess.resource('ec2')
@@ -724,7 +725,7 @@ class AWSCluster(Cluster):
                 if f_id:
                     mins = fact_t * 60 if fact_t > 0 else 5
                     self._create_cloudwatch_event(f_id, mins=mins, cpu_thresh=0.5)
-                    logger.info(cl.YE(f"{f.host} timeout of {mins} set"))
+                    logger.info(cl.YE(f"{f.host} timeout of {mins} mins set"))
         else:
             logger.info(cl.YE(f"Factories have no timeout"))
 
@@ -785,7 +786,7 @@ class AWSCluster(Cluster):
                 Threshold=cpu_thresh,
                 ActionsEnabled=True,
                 AlarmActions=[
-                    'arn:aws:automate:us-east-1:ec2:terminate'
+                    f'arn:aws:automate:{self.region_name}:ec2:terminate'
                 ],
                 AlarmDescription=f'Terminate when CPU < {cpu_thresh}%',
                 Dimensions=[

--- a/flambe/cluster/aws.py
+++ b/flambe/cluster/aws.py
@@ -810,7 +810,7 @@ class AWSCluster(Cluster):
                                     'Value': instance_id
                                 },
                             ],
-                            'Timestamp': datetime.now() - timedelta(minutes=i),
+                            'Timestamp': datetime.utcnow() - timedelta(minutes=i),
                             'Value': 100,
                             'Unit': 'Percent',
                         },

--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -873,7 +873,7 @@ class CPUFactoryInstance(Instance):
         self.install_flambe()
 
     def launch_node(self, redis_address: str) -> None:
-        """Launche the ray worker node.
+        """Launch the ray worker node.
 
         Parameters
         ----------

--- a/flambe/experiment/experiment.py
+++ b/flambe/experiment/experiment.py
@@ -393,9 +393,16 @@ class Experiment(ClusterRunnable):
             self.progress_state.checkpoint_end(block_id, checkpoints, success[block_id])
             logger.debug(f"Done running {block_id}")
 
-        # Close ray experiment
+        # Disconnect process from ray cluster
         ray.shutdown()
-        logger.debug("Shutted down ray cluster")
+
+        # Shutdown ray cluster.
+        if self.env:
+            ret = utils.shutdown_ray_node()
+            logger.debug(f"Node shutdown {'successful' if ret == 0 else 'failed'} in Orchestrator")
+            for f in self.env.factories_ips:
+                ret = utils.shutdown_remote_ray_node(f, "ubuntu", self.env.key)
+                logger.debug(f"Node shutdown {'successful' if ret == 0 else 'failed'} in {f}")
 
         self.progress_state.finish()
 

--- a/flambe/experiment/utils.py
+++ b/flambe/experiment/utils.py
@@ -490,3 +490,34 @@ def rel_to_abs_paths(d: Dict[str, str]) -> Dict[str, str]:
         if os.path.exists(v) and not os.path.isabs(v):
             ret[k] = os.path.abspath(v)
     return ret
+
+
+def shutdown_ray_node() -> int:
+    """Call 'ray stop' locally to terminate
+    the ray node.
+
+    """
+    return os.system("bash -lc 'ray stop'")
+
+
+def shutdown_remote_ray_node(host: str,
+                             user: str,
+                             key: str) -> int:
+    """Execute 'ray stop' on a remote machine through ssh to
+    terminate the ray node.
+
+    IMPORTANT: this method is intended to be run in the cluster.
+
+    Parameters
+    ----------
+    host: str
+        The Orchestrator's IP that is visible by the factories
+        (usually the private IP)
+    user: str
+        The username for that machine.
+    key: str
+        The key that communicate with the machine.
+
+    """
+    cmd = f"ssh -i {key} -o StrictHostKeyChecking=no {user}@{host} \"bash -lc 'ray stop'\""
+    return os.system(cmd)


### PR DESCRIPTION
The problem was that `ray` was still running in all instances after the remote experiment was over and this caused the AWS timeouts to not trigger (because ray caused CPU usage to go up).

Now when a remote experiment is over, flambe will call `ray stop` on all instances.