### PR TITLE
Ignore gitignore when rsyncing flambe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,18 +274,6 @@ tags
 # Persistent undo
 [._]*.un~
 
-### VirtualEnv ###
-# Virtualenv
-# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
-[Bb]in
-[Ii]nclude
-[Ll]ib
-[Ll]ib64
-[Ll]ocal
-[Ss]cripts
-pyvenv.cfg
-pip-selfcheck.json
-
 ### VisualStudioCode ###
 .vscode/
 

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,5 +1,5 @@
 ### profile may optionally select or skip tests
 
-skips: ['B301','B311','B403','B404','B603','B605','B601','B607','B307', 'B110']
+skips: ['B301','B311','B403','B404','B603','B605','B601','B607','B307', 'B110', 'B602']
 
 # See bandit --help for details on each skip

--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -422,6 +422,9 @@ class Instance(object):
             The local filename or folder
         remote_path : str
             The remote filename or folder to use
+        filter_param : str
+            The filter parameter to be passed to rsync.
+            For example, "--filter=':- .gitignore'"
 
         Raises
         ------
@@ -438,7 +441,10 @@ class Instance(object):
 
         _to = f"{self.username}@{self.host if self.use_public else self.private_host}:{remote_path}"
 
-        cmd = f'rsync {filter_param} -ae "ssh -i {self.key} -o StrictHostKeyChecking=no" {_from} {_to}'
+        cmd = (
+            f'rsync {filter_param} -ae "ssh -i {self.key} -o StrictHostKeyChecking=no"'
+            f'{_from} {_to}'
+        )
         try:
             subprocess.check_call(cmd, stdout=subprocess.DEVNULL,
                                   stderr=subprocess.DEVNULL,

--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -413,7 +413,7 @@ class Instance(object):
                 raise errors.RemoteCommandError(f"Error executing {s} in {self.host}. " +
                                                 f"{ret.msg}")
 
-    def send_rsync(self, host_path: str, remote_path: str) -> None:
+    def send_rsync(self, host_path: str, remote_path: str, filter_param: str = "") -> None:
         """Send a local file or folder to a remote instance with rsync.
 
         Parameters
@@ -438,12 +438,11 @@ class Instance(object):
 
         _to = f"{self.username}@{self.host if self.use_public else self.private_host}:{remote_path}"
 
-        cmd = ["rsync", "-ae",
-               f"ssh -i {self.key} -o StrictHostKeyChecking=no",
-               _from, _to]
+        cmd = f'rsync {filter_param} -ae "ssh -i {self.key} -o StrictHostKeyChecking=no" {_from} {_to}'
         try:
             subprocess.check_call(cmd, stdout=subprocess.DEVNULL,
-                                  stderr=subprocess.DEVNULL)
+                                  stderr=subprocess.DEVNULL,
+                                  shell=True)
             logger.debug(f"rsync {host_path} -> {remote_path} successful")
         except subprocess.CalledProcessError as e:
             raise errors.RemoteFileTransferError(e)
@@ -623,8 +622,13 @@ class Instance(object):
 
         else:
             origin = get_flambe_repo_location()
+            # Avoid rsyncing resources from gitignore
+            filter_param = ""
+            if os.path.exists(os.path.join(origin, ".gitignore")):
+                filter_param = f"--filter=':- {os.path.join(origin, '.gitignore')}'"
+
             destiny = os.path.join(self.get_home_path(), "extensions", "flambe")
-            self.send_rsync(origin, destiny)
+            self.send_rsync(origin, destiny, filter_param)
             logger.debug(f"Sent flambe {origin} -> {destiny}")
             pip_destiny = destiny if not self.contains_gpu() else f"{destiny}[cuda]"
             ret = self._run_cmd(

--- a/flambe/cluster/instance/instance.py
+++ b/flambe/cluster/instance/instance.py
@@ -442,7 +442,7 @@ class Instance(object):
         _to = f"{self.username}@{self.host if self.use_public else self.private_host}:{remote_path}"
 
         cmd = (
-            f'rsync {filter_param} -ae "ssh -i {self.key} -o StrictHostKeyChecking=no"'
+            f'rsync {filter_param} -ae "ssh -i {self.key} -o StrictHostKeyChecking=no" '
             f'{_from} {_to}'
         )
         try:


### PR DESCRIPTION
- In dev mode, when rsyncing flambe to the instances all content in gitignore will be ignored. **This makes launching new clusters significantly faster**

- Also, I added a fix in the gitignore file that was not allowing `bin/` to be included.