### PR TITLE
Fixing auc metric when max_fpr < 1

### DIFF
--- a/flambe/metric/dev/auc.py
+++ b/flambe/metric/dev/auc.py
@@ -45,6 +45,13 @@ class AUC(Metric):
 
         # Compute the area under the curve using trapezoidal rule
         max_index = np.searchsorted(fpr, [self.max_fpr], side='right').item()
-        area = np.trapz(tpr[:max_index], fpr[:max_index])
+
+        # Ensure we integrate up to max_fpr
+        fpr, tpr = fpr.tolist(), tpr.tolist()
+        fpr, tpr = fpr[:max_index], tpr[:max_index]
+        fpr.append(self.max_fpr)
+        tpr.append(max(tpr))
+
+        area = np.trapz(tpr, fpr)
 
         return torch.tensor(area / self.max_fpr).float()

--- a/tests/unit/metrics/test_dev.py
+++ b/tests/unit/metrics/test_dev.py
@@ -39,7 +39,7 @@ def test_auc_threshold():
 
     metric_test_case(y_pred, y_true, AUC(max_fpr=1.), sklearn.metrics.roc_auc_score(y_true, y_pred))
     metric_test_case(y_pred, y_true, AUC(max_fpr=0.500001), 0.5)
-    metric_test_case(y_pred, y_true, AUC(max_fpr=0.1), 0)
+    metric_test_case(y_pred, y_true, AUC(max_fpr=0.1), 0.5)
 
 
 def test_auc_empty():


### PR DESCRIPTION
I think there's a bug in the AUC code when using a `max_fpr` that’s less than 1. Here’s an example that produces an incorrect result:

```python
import numpy as np
import matplotlib.pyplot as plt
from sklearn.metrics import roc_curve
from flambe.metric import AUC

scores = np.array([0.4, 0.3, 0.2, 0.1])
targets = np.array([1, 0, 1, 0])

auc = AUC(max_fpr=0.2).compute(scores, targets).item()
print(auc)  # 0.0

fpr, tpr, _ = roc_curve(targets, scores)
plt.plot(fpr, tpr)  # area below fpr = 0.2 is not 0
```

But if you look at the ROC curve plot below, you can see that the area under the curve for a max false positive rate of 0.2 is not 0.

![roc](https://user-images.githubusercontent.com/40181090/63712164-1b510200-c80b-11e9-9b47-8c9f50ae6034.png)

I think the problem is in the way the area is computed when `max_fpr` is not 1. Here’s the flambe code:

```python
fpr, tpr, _ = sklearn.metrics.roc_curve(targets, scores, sample_weight=None)

# Compute the area under the curve using trapezoidal rule
max_index = np.searchsorted(fpr, [self.max_fpr], side='right').item()
area = np.trapz(tpr[:max_index], fpr[:max_index])

return torch.tensor(area / self.max_fpr).float()
```

In the example above, we get:

```python
fpr = [0.0, 0.0, 0.5, 0.5, 1.0]
tpr = [0.0, 0.5, 0.5, 1.0, 1.0]
```

meaning `max_index = 2` and then `area = 0` since `np.trapz` is integrating from `fpr=0.0` to `fpr=0.0`.

I think the appropriate fix would be to ensure that `np.trapz` integrates all the way up to `max_fpr` by doing this:

```python
fpr, tpr, _ = sklearn.metrics.roc_curve(targets, scores, sample_weight=None)

# Compute the area under the curve using trapezoidal rule
max_index = np.searchsorted(fpr, [self.max_fpr], side='right').item()

# Ensure we integrate up to max_fpr
fpr, tpr = fpr.tolist(), tpr.tolist()
fpr, tpr = fpr[:max_index], tpr[:max_index]
fpr.append(self.max_fpr)
tpr.append(max(tpr))

area = np.trapz(tpr, fpr)

return torch.tensor(area / self.max_fpr).float()
```

which produces an area of 0.1 and an auc of 0.5 for `max_fpr = 0.2`.