### PR TITLE
Invert eval/train steps

### DIFF
--- a/flambe/learn/train.py
+++ b/flambe/learn/train.py
@@ -297,6 +297,7 @@ class Trainer(Component):
         self._step += 1
         continue_ = self._step < self.max_steps
         if not continue_:
+            self._eval_step()
             self.model.load_state_dict(self._best_model)
 
         return continue_

--- a/flambe/learn/train.py
+++ b/flambe/learn/train.py
@@ -289,9 +289,9 @@ class Trainer(Component):
             Whether the computable is not yet complete.
 
         """
+        self._eval_step()
         if self._step < self.max_steps:
             self._train_step()
-        self._eval_step()
 
         # Simple stopping rule, if we exceed the max number of steps
         self._step += 1

--- a/flambe/learn/train.py
+++ b/flambe/learn/train.py
@@ -281,7 +281,7 @@ class Trainer(Component):
                 metric(preds, targets).item(), self._step)  # type: ignore
 
     def run(self) -> bool:
-        """Train until the next checkpoint, and evaluate.
+        """Evaluate and then train until the next checkpoint
 
         Returns
         ------


### PR DESCRIPTION
This PR updates the `Trainer.run()` method to perform an evaluation step first and then a trains until the next checkpoint